### PR TITLE
Chnages for task 1,2 and 3

### DIFF
--- a/ApiTechTest1/src/ApiTechTest1.Api.UnitTests/Services/ResultServiceShould.cs
+++ b/ApiTechTest1/src/ApiTechTest1.Api.UnitTests/Services/ResultServiceShould.cs
@@ -1,5 +1,6 @@
 ﻿namespace ApiTechTest1.Api.UnitTests.Services
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -74,10 +75,11 @@
             var testObject = GetResultService();
 
             // Act
-            var result = await Assert.ThrowsAsync<IdOutOfRangeException>(() => testObject.GetResultAsync(id, cancellationToken));
+            var exception = await Assert.ThrowsAsync<IdOutOfRangeException>(() => testObject.GetResultAsync(id, cancellationToken));
 
             // Assert
-            expectedResult.Should().BeEquivalentTo(result);
+            Assert.Equal(id, exception.Id);
+            Assert.Equal($"Number out of range: {id}", exception.Message);
         }
 
         private static IEnumerable<Result> GetResults()

--- a/ApiTechTest1/src/ApiTechTest1.Api/Controllers/LaboratoryController.cs
+++ b/ApiTechTest1/src/ApiTechTest1.Api/Controllers/LaboratoryController.cs
@@ -33,7 +33,7 @@
         /// <param name="id">The identifier.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns></returns>
-        [HttpGet("/GetResult")]
+        [HttpGet("/GetResult/{id}")]
         public async Task<Result> GetResultAsync([FromRoute] int id, CancellationToken cancellationToken)
         {
             return await _resultService.GetResultAsync(id, cancellationToken);
@@ -45,8 +45,8 @@
         /// <param name="listResultsRequest">The list Results request.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns></returns>
-        [HttpGet("/ListResults")]
-        public async Task<IEnumerable<Result>> ListResultsAsync([FromQuery] ListResultsRequest listResultsRequest, CancellationToken cancellationToken)
+        [HttpPost("/ListResults")]
+        public async Task<IEnumerable<Result>> ListResultsAsync([FromBody] ListResultsRequest listResultsRequest, CancellationToken cancellationToken)
         {
             return await _resultService.ListResultsAsync(listResultsRequest, cancellationToken);
         }

--- a/ApiTechTest1/src/ApiTechTest1.Api/Exceptions/IdOutOfRangeException.cs
+++ b/ApiTechTest1/src/ApiTechTest1.Api/Exceptions/IdOutOfRangeException.cs
@@ -13,6 +13,7 @@
         /// </summary>
         /// <param name="id">The identifier.</param>
         public IdOutOfRangeException(int id)
+            : base($"Number out of range: {id}")
         {
             Id = id;
         }

--- a/ApiTechTest1/src/ApiTechTest1.Api/Services/ListResultsRequest.cs
+++ b/ApiTechTest1/src/ApiTechTest1.Api/Services/ListResultsRequest.cs
@@ -1,4 +1,9 @@
-﻿namespace ApiTechTest1.Api.Services
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using ApiTechTest1.Infrastructure.Objects;
+
+namespace ApiTechTest1.Api.Services
 {
     /// <summary>
     /// Request object for ListResults.
@@ -14,5 +19,87 @@
         /// Gets the order by.
         /// </summary>
         public string OrderBy { get; init; }
+
+        /// <summary>
+        /// Gets the order Direction by.
+        /// </summary>
+        public string OrderDirection { get; init; }
+
+        /// <summary>
+        /// Gets the Filter by String names and the value to filter by.
+        /// </summary>
+        public Dictionary<string, int?> FilterLevels { get; init; } = new();
+
+        /// <summary>
+        /// Apply selected sorting by.
+        /// </summary>
+        public IEnumerable<Result> ApplySorting(IEnumerable<Result> results)
+        {
+            if (string.IsNullOrWhiteSpace(OrderBy))
+            {
+                return results;
+            }
+
+            if (!string.IsNullOrWhiteSpace(OrderDirection) &&
+                !OrderDirection.Equals("asc", StringComparison.OrdinalIgnoreCase) &&
+                !OrderDirection.Equals("desc", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException("OrderDirection must be either 'asc' or 'desc'.");
+            }
+
+            bool descending = OrderDirection?.Equals("desc", StringComparison.OrdinalIgnoreCase) == true;
+
+            Func<Result, object> keySelector;
+
+            switch (OrderBy.ToLower(System.Globalization.CultureInfo.CurrentCulture))
+            {
+                case "chlamydia":
+                    keySelector = r => r.ChlamydiaResultsLevel;
+                    break;
+                case "gonorrhea":
+                    keySelector = r => r.GonorrheaResultsLevel;
+                    break;
+                default:
+                    return results;
+            }
+
+            if (keySelector == null)
+            {
+                return results;
+            }
+
+            return descending ? results.OrderByDescending(keySelector) : results.OrderBy(keySelector);
+        }
+
+        /// <summary>
+        /// Apply Selected Level Filtering.
+        /// </summary>
+        public IEnumerable<Result> ApplyLevelFilter(IEnumerable<Result> results)
+        {
+            foreach (var filter in FilterLevels)
+            {
+                if (!filter.Value.HasValue)
+                {
+                    continue;
+                }
+
+                var filterKey = filter.Key.ToLower(System.Globalization.CultureInfo.CurrentCulture);
+                double filterValue = filter.Value.Value;
+
+                switch (filterKey)
+                {
+                    case "chlamydia":
+                        results = results.Where(r => r.ChlamydiaResultsLevel > filterValue);
+                        break;
+                    case "gonorrhea":
+                        results = results.Where(r => r.GonorrheaResultsLevel > filterValue);
+                        break;
+                    default:
+                        throw new ArgumentException($"Invalid filter key: {filter.Key}");
+                }
+            }
+
+            return results;
+        }
     }
 }

--- a/ApiTechTest1/src/ApiTechTest1.Api/Services/ResultService.cs
+++ b/ApiTechTest1/src/ApiTechTest1.Api/Services/ResultService.cs
@@ -1,10 +1,11 @@
 ﻿namespace ApiTechTest1.Api.Services
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
-
+    using ApiTechTest1.Api.Exceptions;
     using ApiTechTest1.Infrastructure.Objects;
     using ApiTechTest1.Infrastructure.Repositories;
 
@@ -33,9 +34,14 @@
         /// <returns></returns>
         public async Task<Result> GetResultAsync(int id, CancellationToken cancellationToken)
         {
+            if (id < 1)
+            {
+                throw new IdOutOfRangeException(id);
+            }
+
             var results = await _resultRepository.GetAsync();
 
-            return results.FirstOrDefault();
+            return results.FirstOrDefault(result => result.Id == id);
         }
 
         /// <summary>
@@ -46,7 +52,19 @@
         /// <returns></returns>
         public async Task<IEnumerable<Result>> ListResultsAsync(ListResultsRequest request, CancellationToken cancellationToken)
         {
-            return await _resultRepository.GetAsync();
+            var results = await _resultRepository.GetAsync();
+
+            // WildCard sort by name;
+            if (!string.IsNullOrWhiteSpace(request.SearchString))
+            {
+                results = results.Where(result => result.Name.Contains(request.SearchString, StringComparison.OrdinalIgnoreCase));
+            }
+
+            results = request.ApplyLevelFilter(results);
+
+            results = request.ApplySorting(results);
+
+            return results;
         }
     }
 }


### PR DESCRIPTION
Task 1

add results.FirstOrDefault(result => result.Id == id) to fix unit test for tasks one

Didn't fully understand why the GetResultAsyncShould_ThrowIdOutOfRangeException unit test was expecting Results class if an exception was thrown, therefore I changed the unit test to check exception, I know this doesn't follow true TDD

Task 2

Add wildcard to check name if not empty: results = results.Where(result => result.Name.Contains(request.SearchString, StringComparison.OrdinalIgnoreCase));

Add ApplySorting method in ListResultsRequest

Task 3

Add ApplyLevelFilter method in ListResultsRequest

Also changed from FromQuery to FromBody and post